### PR TITLE
feat: enrich subscription fanout telemetry for PLA-1448

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -191,32 +191,37 @@ defmodule Absinthe.Subscription do
 
   @doc false
   def get(pubsub, key) do
-    {docs, _entry_count} = get_with_entry_count(pubsub, key)
+    {docs, _entry_count, _subscriber_counts} = get_with_counts(pubsub, key)
     docs
   end
 
   @doc false
   def get_with_entry_count(pubsub, key) do
+    {docs, entry_count, _subscriber_counts} = get_with_counts(pubsub, key)
+    {docs, entry_count}
+  end
+
+  @doc false
+  def get_with_counts(pubsub, key) do
     name = registry_name(pubsub)
 
     entries = Registry.lookup(name, key)
 
-    docs =
+    {docs, subscriber_counts} =
       entries
       |> MapSet.new(fn {_pid, doc_id} -> doc_id end)
-      |> Enum.reduce([], fn doc_id, acc ->
+      |> Enum.reduce({[], %{}}, fn doc_id, {docs, subscriber_counts} ->
         case Registry.lookup(name, doc_id) do
           [] ->
-            acc
+            {docs, subscriber_counts}
 
-          [{_pid, doc} | _rest] ->
+          [{_pid, doc} | _rest] = doc_entries ->
             doc = Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
-            [{doc_id, doc} | acc]
+            {[{doc_id, doc} | docs], Map.put(subscriber_counts, doc_id, length(doc_entries))}
         end
       end)
-      |> Map.new()
 
-    {docs, length(entries)}
+    {Map.new(docs), length(entries), subscriber_counts}
   end
 
   @doc false

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -191,22 +191,32 @@ defmodule Absinthe.Subscription do
 
   @doc false
   def get(pubsub, key) do
+    {docs, _entry_count} = get_with_entry_count(pubsub, key)
+    docs
+  end
+
+  @doc false
+  def get_with_entry_count(pubsub, key) do
     name = registry_name(pubsub)
 
-    name
-    |> Registry.lookup(key)
-    |> MapSet.new(fn {_pid, doc_id} -> doc_id end)
-    |> Enum.reduce([], fn doc_id, acc ->
-      case Registry.lookup(name, doc_id) do
-        [] ->
-          acc
+    entries = Registry.lookup(name, key)
 
-        [{_pid, doc} | _rest] ->
-          doc = Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
-          [{doc_id, doc} | acc]
-      end
-    end)
-    |> Map.new()
+    docs =
+      entries
+      |> MapSet.new(fn {_pid, doc_id} -> doc_id end)
+      |> Enum.reduce([], fn doc_id, acc ->
+        case Registry.lookup(name, doc_id) do
+          [] ->
+            acc
+
+          [{_pid, doc} | _rest] ->
+            doc = Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
+            [{doc_id, doc} | acc]
+        end
+      end)
+      |> Map.new()
+
+    {docs, length(entries)}
   end
 
   @doc false

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -22,10 +22,12 @@ defmodule Absinthe.Subscription.Local do
           [Absinthe.Subscription.subscription_field_spec()]
         ) :: :ok
   def publish_mutation(pubsub, mutation_result, subscribed_fields) do
-    {docs_and_topics, fields_by_topic} =
-      Enum.reduce(subscribed_fields, {[], %{}}, fn {field, key_strategy},
-                                                   {docs_and_topics, fields_by_topic} ->
-        docs = get_docs_with_telemetry(pubsub, field, mutation_result, key_strategy)
+    {docs_and_topic_batches, fields_by_topic, subscriber_counts_by_topic} =
+      Enum.reduce(subscribed_fields, {[], %{}, %{}}, fn {field, key_strategy},
+                                                        {docs_and_topic_batches, fields_by_topic,
+                                                         subscriber_counts_by_topic} ->
+        {docs, field_subscriber_counts} =
+          get_docs_with_telemetry(pubsub, field, mutation_result, key_strategy)
 
         docs_and_topics_for_field =
           Enum.map(docs, fn {topic, doc} -> {topic, key_strategy, doc} end)
@@ -35,8 +37,17 @@ defmodule Absinthe.Subscription.Local do
             Map.put_new(fields_by_topic, topic, field)
           end)
 
-        {docs_and_topics ++ docs_and_topics_for_field, fields_by_topic}
+        {
+          [docs_and_topics_for_field | docs_and_topic_batches],
+          fields_by_topic,
+          Map.merge(subscriber_counts_by_topic, field_subscriber_counts)
+        }
       end)
+
+    docs_and_topics =
+      docs_and_topic_batches
+      |> Enum.reverse()
+      |> :lists.append()
 
     run_docset_field = run_docset_field(fields_by_topic, subscribed_fields)
 
@@ -45,7 +56,13 @@ defmodule Absinthe.Subscription.Local do
         &pubsub.run_docset/3
       else
         fn pubsub, docs_and_topics, mutation_result ->
-          run_docset(pubsub, docs_and_topics, mutation_result, fields_by_topic)
+          run_docset(
+            pubsub,
+            docs_and_topics,
+            mutation_result,
+            fields_by_topic,
+            subscriber_counts_by_topic
+          )
         end
       end
 
@@ -78,11 +95,11 @@ defmodule Absinthe.Subscription.Local do
         key_strategy: key_strategy
       },
       fn ->
-        {docs, entries_scanned, doc_count} =
+        {docs, entries_scanned, doc_count, subscriber_counts_by_topic} =
           get_docs(pubsub, field, mutation_result, key_strategy)
 
         {
-          docs,
+          {docs, subscriber_counts_by_topic},
           %{entries_scanned: entries_scanned, doc_count: doc_count},
           field_metadata(field)
         }
@@ -90,11 +107,18 @@ defmodule Absinthe.Subscription.Local do
     )
   end
 
-  defp run_docset(pubsub, docs_and_topics, mutation_result, fields_by_topic) do
+  defp run_docset(
+         pubsub,
+         docs_and_topics,
+         mutation_result,
+         fields_by_topic,
+         subscriber_counts_by_topic
+       ) do
     for {topic, key_strategy, doc} <- docs_and_topics do
       try do
         pipeline = pipeline(doc, mutation_result)
         field = Map.get(fields_by_topic, topic)
+        subscriber_count = Map.get(subscriber_counts_by_topic, topic, 0)
 
         {:ok, %{result: data}, _} = Absinthe.Pipeline.run(doc.source, pipeline)
 
@@ -105,7 +129,7 @@ defmodule Absinthe.Subscription.Local do
         Data: #{inspect(data)}
         """)
 
-        :ok = dispatch_with_telemetry(pubsub, field, topic, data)
+        :ok = dispatch_with_telemetry(pubsub, field, topic, data, subscriber_count)
       rescue
         e ->
           BatchResolver.pipeline_error(e, __STACKTRACE__)
@@ -148,27 +172,40 @@ defmodule Absinthe.Subscription.Local do
   end
 
   defp do_get_docs(pubsub, field, keys) do
-    {docs, entries_scanned, doc_ids} =
+    {doc_batches, entries_scanned, doc_ids, subscriber_counts_by_topic} =
       keys
       |> List.wrap()
       |> Enum.map(&to_string/1)
-      |> Enum.reduce({[], 0, MapSet.new()}, fn key, {docs, entries_scanned, doc_ids} ->
-        {key_docs, entry_count} = Absinthe.Subscription.get_with_entry_count(pubsub, {field, key})
+      |> Enum.reduce({[], 0, MapSet.new(), %{}}, fn key,
+                                                    {doc_batches, entries_scanned, doc_ids,
+                                                     subscriber_counts_by_topic} ->
+        {key_docs, entry_count, key_subscriber_counts} =
+          Absinthe.Subscription.get_with_counts(pubsub, {field, key})
+
+        key_docs = Enum.to_list(key_docs)
 
         doc_ids =
           Enum.reduce(key_docs, doc_ids, fn {doc_id, _doc}, doc_ids ->
             MapSet.put(doc_ids, doc_id)
           end)
 
-        {docs ++ Enum.to_list(key_docs), entries_scanned + entry_count, doc_ids}
+        {
+          [key_docs | doc_batches],
+          entries_scanned + entry_count,
+          doc_ids,
+          Map.merge(subscriber_counts_by_topic, key_subscriber_counts)
+        }
       end)
 
-    {docs, entries_scanned, MapSet.size(doc_ids)}
+    docs =
+      doc_batches
+      |> Enum.reverse()
+      |> :lists.append()
+
+    {docs, entries_scanned, MapSet.size(doc_ids), subscriber_counts_by_topic}
   end
 
-  defp dispatch_with_telemetry(pubsub, field, topic, data) do
-    subscriber_count = subscriber_count(pubsub, topic)
-
+  defp dispatch_with_telemetry(pubsub, field, topic, data, subscriber_count) do
     :telemetry.span(
       [:absinthe, :subscription, :local, :dispatch],
       field_metadata(field),
@@ -180,13 +217,6 @@ defmodule Absinthe.Subscription.Local do
         }
       end
     )
-  end
-
-  defp subscriber_count(pubsub, topic) do
-    pubsub
-    |> Absinthe.Subscription.registry_name()
-    |> Registry.lookup(topic)
-    |> length()
   end
 
   defp doc_count(docs_and_topics) do

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -22,14 +22,32 @@ defmodule Absinthe.Subscription.Local do
           [Absinthe.Subscription.subscription_field_spec()]
         ) :: :ok
   def publish_mutation(pubsub, mutation_result, subscribed_fields) do
-    docs_and_topics =
-      for {field, key_strategy} <- subscribed_fields,
-          {topic, doc} <- get_docs_with_telemetry(pubsub, field, mutation_result, key_strategy) do
-        {topic, key_strategy, doc}
-      end
+    {docs_and_topics, fields_by_topic} =
+      Enum.reduce(subscribed_fields, {[], %{}}, fn {field, key_strategy},
+                                                   {docs_and_topics, fields_by_topic} ->
+        docs = get_docs_with_telemetry(pubsub, field, mutation_result, key_strategy)
+
+        docs_and_topics_for_field =
+          Enum.map(docs, fn {topic, doc} -> {topic, key_strategy, doc} end)
+
+        fields_by_topic =
+          Enum.reduce(docs, fields_by_topic, fn {topic, _doc}, fields_by_topic ->
+            Map.put_new(fields_by_topic, topic, field)
+          end)
+
+        {docs_and_topics ++ docs_and_topics_for_field, fields_by_topic}
+      end)
+
+    run_docset_field = run_docset_field(fields_by_topic, subscribed_fields)
 
     run_docset_fn =
-      if function_exported?(pubsub, :run_docset, 3), do: &pubsub.run_docset/3, else: &run_docset/3
+      if function_exported?(pubsub, :run_docset, 3) do
+        &pubsub.run_docset/3
+      else
+        fn pubsub, docs_and_topics, mutation_result ->
+          run_docset(pubsub, docs_and_topics, mutation_result, fields_by_topic)
+        end
+      end
 
     :telemetry.span(
       [:absinthe, :subscription, :local, :run_docset],
@@ -39,7 +57,11 @@ defmodule Absinthe.Subscription.Local do
         docs_and_topics: docs_and_topics
       },
       fn ->
-        {run_docset_fn.(pubsub, docs_and_topics, mutation_result), %{}}
+        {
+          run_docset_fn.(pubsub, docs_and_topics, mutation_result),
+          %{doc_count: doc_count(docs_and_topics)},
+          field_metadata(run_docset_field)
+        }
       end
     )
 
@@ -56,15 +78,23 @@ defmodule Absinthe.Subscription.Local do
         key_strategy: key_strategy
       },
       fn ->
-        {get_docs(pubsub, field, mutation_result, key_strategy), %{}}
+        {docs, entries_scanned, doc_count} =
+          get_docs(pubsub, field, mutation_result, key_strategy)
+
+        {
+          docs,
+          %{entries_scanned: entries_scanned, doc_count: doc_count},
+          field_metadata(field)
+        }
       end
     )
   end
 
-  defp run_docset(pubsub, docs_and_topics, mutation_result) do
+  defp run_docset(pubsub, docs_and_topics, mutation_result, fields_by_topic) do
     for {topic, key_strategy, doc} <- docs_and_topics do
       try do
         pipeline = pipeline(doc, mutation_result)
+        field = Map.get(fields_by_topic, topic)
 
         {:ok, %{result: data}, _} = Absinthe.Pipeline.run(doc.source, pipeline)
 
@@ -75,7 +105,7 @@ defmodule Absinthe.Subscription.Local do
         Data: #{inspect(data)}
         """)
 
-        :ok = pubsub.publish_subscription(topic, data)
+        :ok = dispatch_with_telemetry(pubsub, field, topic, data)
       rescue
         e ->
           BatchResolver.pipeline_error(e, __STACKTRACE__)
@@ -118,11 +148,73 @@ defmodule Absinthe.Subscription.Local do
   end
 
   defp do_get_docs(pubsub, field, keys) do
-    keys
-    |> List.wrap()
-    |> Enum.map(&to_string/1)
-    |> Enum.flat_map(&Absinthe.Subscription.get(pubsub, {field, &1}))
+    {docs, entries_scanned, doc_ids} =
+      keys
+      |> List.wrap()
+      |> Enum.map(&to_string/1)
+      |> Enum.reduce({[], 0, MapSet.new()}, fn key, {docs, entries_scanned, doc_ids} ->
+        {key_docs, entry_count} = Absinthe.Subscription.get_with_entry_count(pubsub, {field, key})
+
+        doc_ids =
+          Enum.reduce(key_docs, doc_ids, fn {doc_id, _doc}, doc_ids ->
+            MapSet.put(doc_ids, doc_id)
+          end)
+
+        {docs ++ Enum.to_list(key_docs), entries_scanned + entry_count, doc_ids}
+      end)
+
+    {docs, entries_scanned, MapSet.size(doc_ids)}
   end
+
+  defp dispatch_with_telemetry(pubsub, field, topic, data) do
+    subscriber_count = subscriber_count(pubsub, topic)
+
+    :telemetry.span(
+      [:absinthe, :subscription, :local, :dispatch],
+      field_metadata(field),
+      fn ->
+        {
+          pubsub.publish_subscription(topic, data),
+          %{subscriber_count: subscriber_count},
+          field_metadata(field)
+        }
+      end
+    )
+  end
+
+  defp subscriber_count(pubsub, topic) do
+    pubsub
+    |> Absinthe.Subscription.registry_name()
+    |> Registry.lookup(topic)
+    |> length()
+  end
+
+  defp doc_count(docs_and_topics) do
+    docs_and_topics
+    |> Enum.map(fn {topic, _key_strategy, _doc} -> topic end)
+    |> MapSet.new()
+    |> MapSet.size()
+  end
+
+  defp run_docset_field(fields_by_topic, subscribed_fields) do
+    case available_field(Map.values(fields_by_topic)) do
+      nil -> available_field(Keyword.keys(subscribed_fields))
+      field -> field
+    end
+  end
+
+  defp available_field(fields) do
+    fields
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> case do
+      [field] -> field
+      _ -> nil
+    end
+  end
+
+  defp field_metadata(nil), do: %{}
+  defp field_metadata(field), do: %{field: field}
 
   defp result_phase(doc) do
     # use the configured result phase from the initial pipeline

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule Absinthe.Mixfile do
   defp deps do
     [
       {:nimble_parsec, "~> 1.2.2 or ~> 1.3"},
-      {:telemetry, "~> 1.0 or ~> 0.4"},
+      {:telemetry, "~> 1.3"},
       {:dataloader, "~> 1.0.0 or ~> 2.0", optional: true},
       {:decimal, "~> 2.0", optional: true},
       {:opentelemetry_process_propagator, "~> 0.3 or ~> 0.2.1", optional: true},

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -788,8 +788,10 @@ defmodule Absinthe.Execution.SubscriptionTest do
         [:absinthe, :subscription, :publish, :stop],
         [:absinthe, :subscription, :local, :get_docs, :start],
         [:absinthe, :subscription, :local, :run_docset, :start],
+        [:absinthe, :subscription, :local, :dispatch, :start],
         [:absinthe, :subscription, :local, :get_docs, :stop],
-        [:absinthe, :subscription, :local, :run_docset, :stop]
+        [:absinthe, :subscription, :local, :run_docset, :stop],
+        [:absinthe, :subscription, :local, :dispatch, :stop]
       ],
       &Absinthe.TestTelemetryHelper.send_to_pid/4,
       %{}
@@ -836,9 +838,11 @@ defmodule Absinthe.Execution.SubscriptionTest do
     assert is_reference(metadata.telemetry_span_context)
 
     assert_receive {:telemetry_event,
-                    {[:absinthe, :subscription, :local, :get_docs, :stop], _, metadata, _config}}
+                    {[:absinthe, :subscription, :local, :get_docs, :stop], measurements, metadata,
+                     _config}}
 
-    assert %{} == Map.drop(metadata, [:telemetry_span_context])
+    assert %{entries_scanned: 1, doc_count: 1} = measurements
+    assert %{field: :thing} == Map.drop(metadata, [:telemetry_span_context])
     assert is_reference(metadata.telemetry_span_context)
 
     assert_receive {:telemetry_event,
@@ -850,11 +854,81 @@ defmodule Absinthe.Execution.SubscriptionTest do
     assert is_function(metadata.run_docset_fn, 3)
 
     assert_receive {:telemetry_event,
-                    {[:absinthe, :subscription, :local, :run_docset, :stop], _, metadata, _config}}
+                    {[:absinthe, :subscription, :local, :dispatch, :start], _, metadata, _config}}
 
+    assert %{field: :thing} == Map.drop(metadata, [:telemetry_span_context])
+    assert is_reference(metadata.telemetry_span_context)
+
+    assert_receive {:telemetry_event,
+                    {[:absinthe, :subscription, :local, :dispatch, :stop], measurements, metadata,
+                     _config}}
+
+    assert %{subscriber_count: 1} = measurements
+    assert %{field: :thing} == Map.drop(metadata, [:telemetry_span_context])
+    assert is_reference(metadata.telemetry_span_context)
+
+    assert_receive {:telemetry_event,
+                    {[:absinthe, :subscription, :local, :run_docset, :stop], measurements,
+                     metadata, _config}}
+
+    assert %{doc_count: 1} = measurements
+    assert %{field: :thing} == Map.drop(metadata, [:telemetry_span_context])
     assert is_reference(metadata.telemetry_span_context)
 
     :telemetry.detach(context.test)
+  end
+
+  @query """
+  subscription {
+    otherUser { id }
+  }
+  """
+  test "subscription fanout stop telemetry reports scanned entries and subscriber count",
+       context do
+    :telemetry.attach_many(
+      context.test,
+      [
+        [:absinthe, :subscription, :local, :get_docs, :stop],
+        [:absinthe, :subscription, :local, :run_docset, :stop],
+        [:absinthe, :subscription, :local, :dispatch, :stop]
+      ],
+      &Absinthe.TestTelemetryHelper.send_to_pid/4,
+      %{}
+    )
+
+    on_exit(fn -> :telemetry.detach(context.test) end)
+
+    assert {:ok, %{"subscribed" => topic}} =
+             run_subscription(@query, Schema, context: %{context_id: "logged-in"})
+
+    assert {:ok, %{"subscribed" => ^topic}} =
+             run_subscription(@query, Schema, context: %{context_id: "logged-in"})
+
+    Absinthe.Subscription.publish(PubSub, %{id: "global_user_id"}, other_user: "*")
+
+    assert_receive({:broadcast, %{topic: ^topic}})
+    assert_receive({:broadcast, %{topic: ^topic}})
+
+    assert_receive {:telemetry_event,
+                    {[:absinthe, :subscription, :local, :get_docs, :stop], measurements, metadata,
+                     _config}}
+
+    assert %{entries_scanned: 2, doc_count: 1} = measurements
+    assert %{field: :other_user} == Map.drop(metadata, [:telemetry_span_context])
+
+    assert_receive {:telemetry_event,
+                    {[:absinthe, :subscription, :local, :dispatch, :stop], measurements, metadata,
+                     _config}}
+
+    assert %{subscriber_count: 2} = measurements
+    assert %{field: :other_user} == Map.drop(metadata, [:telemetry_span_context])
+
+    assert_receive {:telemetry_event,
+                    {[:absinthe, :subscription, :local, :run_docset, :stop], measurements,
+                     metadata, _config}}
+
+    assert %{doc_count: 1} = measurements
+    assert %{field: :other_user} == Map.drop(metadata, [:telemetry_span_context])
   end
 
   @query """


### PR DESCRIPTION
## Summary

- Enrich get_docs and run_docset subscription fanout :stop events with low-cardinality metrics data.
- Add a dedicated local dispatch span around publish_subscription/2 with field metadata and subscriber_count measurement.
- Add focused subscription telemetry assertions, including duplicate subscriber coverage where scanned entries and unique docs diverge.

## Why

Consumers need to attach only to :stop events and record duration, document counts, scanned registration entries, and field tags without joining span context from :start events.

## Validation

- mix test test/absinthe/execution/subscription_test.exs
- mix test
